### PR TITLE
Generate a server.sh wrapper script with all paths/LANG setup

### DIFF
--- a/lib/mcp/rails/server_generator.rb
+++ b/lib/mcp/rails/server_generator.rb
@@ -21,6 +21,8 @@ module MCP
               bypass_csrf_key
             )
             generated_files << file_path
+            ServerWriter.write_wrapper_script(config, file_path, nil)
+            generated_files << file_path
           end
 
           # Process each engine's routes
@@ -38,6 +40,8 @@ module MCP
               bypass_csrf_key,
               engine
             )
+            generated_files << file_path
+            ServerWriter.write_wrapper_script(config, file_path, engine)
             generated_files << file_path
           end
 

--- a/lib/mcp/rails/server_generator/server_writer.rb
+++ b/lib/mcp/rails/server_generator/server_writer.rb
@@ -10,7 +10,7 @@ module MCP
         FileUtils.mkdir_p(File.dirname(file_path))
 
         File.open(file_path, "w") do |file|
-          file.puts ruby_invocation
+          file.puts "#!/usr/bin/env ruby"
           file.puts
           file.puts %(require "mcp")
           file.puts %(require "httparty")
@@ -38,6 +38,63 @@ module MCP
         File.chmod(new_mode, file_path)
 
         file_path
+      end
+
+      def self.write_wrapper_script(config, server_rb_path, engine = nil)
+        # Get engine-specific configuration if available
+        config = config.for_engine(engine)
+
+        server_rb = engine ? "#{config.server_name}_server.rb" : "server.rb"
+        wrapper_file_name = engine ? "#{config.server_name}_server.sh" : "server.sh"
+        wrapper_file_path = File.join(config.output_directory.to_s, wrapper_file_name)
+        FileUtils.mkdir_p(File.dirname(wrapper_file_path))
+
+        # Determine paths and environment variables
+        bundle_gemfile = ENV["BUNDLE_GEMFILE"] || self.find_nearest_gemfile(config.output_directory.to_s) || ""
+        gem_home = Gem.paths.home
+        gem_path = Gem.paths.path.join(":")
+        bundle_path = ENV["BUNDLE_PATH"] || gem_home # Use BUNDLE_PATH if set, else default to GEM_HOME
+        ruby_executable = RbConfig.ruby # Get the path to the current Ruby executable
+
+        # Construct the wrapper script content
+        script_content = <<~SHELL
+          #!/bin/bash
+
+          export BUNDLE_GEMFILE=#{bundle_gemfile.shellescape}
+          export GEM_HOME=#{gem_home.shellescape}
+          export GEM_PATH=#{gem_path.shellescape}
+          export BUNDLE_PATH=#{bundle_path.shellescape}
+          export PATH=#{File.dirname(ruby_executable).shellescape}:$PATH
+          export LANG=en_US.UTF-8
+
+          DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+          exec "#{ruby_executable.shellescape}" "${DIR}/#{server_rb}" "$@"
+        SHELL
+
+        # Write the script file
+        File.open(wrapper_file_path, "w") do |file|
+          file.puts script_content
+        end
+
+        # Make the script executable
+        current_mode = File.stat(wrapper_file_path).mode
+        new_mode = current_mode | 0111 # Add execute (u+x, g+x, o+x)
+        File.chmod(new_mode, wrapper_file_path)
+
+        wrapper_file_path
+      end
+
+      def self.find_nearest_gemfile(start_dir)
+        current_dir = File.expand_path(start_dir)
+        loop do
+          gemfile = File.join(current_dir, "Gemfile")
+          return gemfile if File.exist?(gemfile)
+          parent_dir = File.dirname(current_dir)
+          break if parent_dir == current_dir # Reached root (e.g., "/")
+          current_dir = parent_dir
+        end
+        nil # No Gemfile found
       end
 
       def self.type_to_class(type)
@@ -78,36 +135,6 @@ module MCP
           type_str = type_to_class(param[:type])
           "#{indent}argument :#{name}, #{type_str}#{required}#{description}"
         end
-      end
-
-      def self.ruby_invocation
-        <<~RUBY
-          #!/usr/bin/env ruby
-
-          # Find the nearest Gemfile by walking up the directory tree
-          def find_nearest_gemfile(start_dir)
-            current_dir = File.expand_path(start_dir)
-            loop do
-              gemfile = File.join(current_dir, "Gemfile")
-              return gemfile if File.exist?(gemfile)
-              parent_dir = File.dirname(current_dir)
-              break if parent_dir == current_dir # Reached root (e.g., "/")
-              current_dir = parent_dir
-            end
-            nil # No Gemfile found
-          end
-
-          # If not already running under bundle exec, re-execute with the nearest Gemfile
-          unless ENV["BUNDLE_GEMFILE"] # Check if already running under Bundler
-            gemfile = find_nearest_gemfile(__dir__) # __dir__ is the script's directory
-            if gemfile
-              ENV["BUNDLE_GEMFILE"] = gemfile
-              exec("bundle", "exec", "ruby", __FILE__, *ARGV) # Re-run with bundle exec
-            else
-              warn "Warning: No Gemfile found in any parent directory."
-            end
-          end
-        RUBY
       end
 
       def self.helper_methods(base_uri, bypass_csrf_key)

--- a/test/dummy/db/migrate
+++ b/test/dummy/db/migrate
@@ -1,0 +1,1 @@
+../../db/gaggle_migrate

--- a/test/mcp/rails/server_generator_test.rb
+++ b/test/mcp/rails/server_generator_test.rb
@@ -146,6 +146,36 @@ module MCP
         normalized_content = content.gsub(/\s+/, "").gsub(/\\"/, '"')
         assert_match(nested_parameters, normalized_content)
       end
+
+      test "generates executable wrapper script with correct content" do
+        server_rb_paths = @generator.generate_files
+        refute_empty server_rb_paths, "No server files were generated"
+
+        server_rb_paths.each do |server_rb_path|
+          wrapper_sh_path = server_rb_path.sub(/\.rb$/, ".sh")
+
+          assert File.exist?(wrapper_sh_path), "Wrapper script #{wrapper_sh_path} does not exist"
+          assert File.executable?(wrapper_sh_path), "Wrapper script #{wrapper_sh_path} is not executable"
+
+          content = File.read(wrapper_sh_path)
+
+          # Verify shebang
+          assert_match(/^#!\/bin\/bash/, content.lines.first)
+
+          # Verify environment variable exports (basic check for presence)
+          assert_match(/^export BUNDLE_GEMFILE=/, content)
+          assert_match(/^export GEM_HOME=/, content)
+          assert_match(/^export GEM_PATH=/, content)
+          assert_match(/^export BUNDLE_PATH=/, content)
+          assert_match(/^export PATH=.*:\$PATH/, content) # Check if Ruby bin dir is added to PATH
+          assert_match(/^export LANG=en_US\.UTF-8/, content)
+
+          # Verify exec command
+          ruby_executable = RbConfig.ruby.shellescape
+          server_rb_escaped_path = server_rb_path.shellescape
+          assert_match(/^exec #{ruby_executable} #{server_rb_escaped_path} "\$@"$/, content)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
I had all manner of problems getting Claude Desktop and Cline to run my `tmp/mcp/server.rb` executable on my MacOS, for problems such as:

* it defaulted to the system ruby 2.6, which I don't use for anything and so bundler et al gems were missing
* the `$LANG` was not set to UTF-8
* I wanted it to use the same Ruby/RubyGems I was developing my app, including using mise or whatever for my Ruby.

The solution was to handcraft a companion `server.sh` script such as the example below.

This PR adds support for generating this server.sh file next to the server.rb file

```sh
#!/bin/bash

export BUNDLE_GEMFILE=/private/tmp/test-mcp-server/Gemfile
export GEM_HOME=/Users/drnic/.local/share/mise/installs/ruby/3.4.2/lib/ruby/gems/3.4.0
export GEM_PATH=/Users/drnic/.gem/ruby/3.4.0:/Users/drnic/.local/share/mise/installs/ruby/3.4.2/lib/ruby/gems/3.4.0
export BUNDLE_PATH=/Users/drnic/.local/share/mise/installs/ruby/3.4.2/lib/ruby/gems/3.4.0
export PATH=/Users/drnic/.local/share/mise/installs/ruby/3.4.2/bin:$PATH
export LANG=en_US.UTF-8

DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

exec /Users/drnic/.local/share/mise/installs/ruby/3.4.2/bin/ruby "${DIR}/server.rb" "$@"
```